### PR TITLE
Add Qwen 3 235B preset to paramcalc

### DIFF
--- a/paramcalc.html
+++ b/paramcalc.html
@@ -26,6 +26,7 @@
             <option value="deepseek-r1-0528">DeepSeek R1 0528</option>
             <option value="deepseek-r1-0528-mtp">DeepSeek R1 0528 MTP</option>
             <option value="glm-5">GLM 5</option>
+            <option value="qwen3-235b">Qwen 3 235B</option>
           </select>
         </div>
       </div>

--- a/paramcalc.js
+++ b/paramcalc.js
@@ -626,6 +626,71 @@ function prefillParamModel(model) {
     // Update computed A and render
     updateComputedTotalLayers();
     calculateAndRender({ scroll: false });
+  } else if (model === 'qwen3-235b') {
+    // B, C
+    setVal('dense_layers', '0'); // B
+    setVal('moe_layers', '94'); // C
+
+    // D: Embedding/output matrices
+    setVal('embedding_shapes', [
+      '[151936, 4096]',
+      '[151936, 4096]'
+    ].join('\n'));
+
+    // E: Pre/post first/last norms (optional)
+    setVal('pre_first_norms', [
+      '[4096]'
+    ].join('\n'));
+
+    // F/G/H: Dense layers are unused for this model
+    setVal('dense_norms', '');
+    setVal('dense_attn', '');
+    setVal('dense_ffn', '');
+
+    // I, J
+    setVal('experts_per_layer', '128'); // I
+    setVal('active_experts', '8'); // J
+
+    // K, L, M: Shared expert disabled
+    setChecked('has_shared_expert', false);
+    updateSharedState();
+    setVal('shared_expert_scope', 'per_layer');
+    setVal('shared_expert_tensors', '');
+
+    // N: MoE attention tensors
+    setVal('moe_attn', [
+      '[8192, 4096]',
+      '[512, 4096]',
+      '[512, 4096]',
+      '[4096, 8192]'
+    ].join('\n'));
+
+    // O: MoE norms/transitional
+    setVal('moe_transitional', [
+      '[4096]',
+      '[4096]',
+      '[128]',
+      '[128]'
+    ].join('\n'));
+
+    // P: Gate input, biases, other FFN (always active)
+    setVal('moe_shared_ffn', [
+      '[128, 4096]'
+    ].join('\n'));
+
+    // Q: MoE experts tensors (includes expert dimension E)
+    setVal('moe_experts', [
+      '[128, 1536, 4096]',
+      '[128, 1536, 4096]',
+      '[128, 4096, 1536]'
+    ].join('\n'));
+
+    // Experts include E: checked
+    setChecked('experts_include_dim', true);
+
+    // Update computed A and render
+    updateComputedTotalLayers();
+    calculateAndRender({ scroll: false });
   } else if (model === 'deepseek-r1-0528-mtp') {
     // Start from base DeepSeek R1 0528, then override differences
     prefillParamModel('deepseek-r1-0528');


### PR DESCRIPTION
### Motivation
- Provide a built‑in preset for the Qwen 3 235B MoE checkpoint so users can quickly populate the parameter calculator with validated HF shapes and MoE settings.

### Description
- Add `Qwen 3 235B` option to the model dropdown in `paramcalc.html` and implement a `qwen3-235b` prefill branch in `paramcalc.js`.
- Populate the preset with the supplied HF-shape values: `B=0`, `C=94`, embeddings `[151936, 4096]` (twice), pre/post norm `[4096]`, `I=128`, `J=8`, shared expert disabled, and expert tensors/attention/gate shapes per the provided specs (`N/O/P/Q`).
- Clear dense-layer fields (`F/G/H`) for this model and enable the expert-dimension mode (`experts_include_dim`).
- Files modified: `paramcalc.html`, `paramcalc.js`.

### Testing
- Ran syntax check: `node --check paramcalc.js` and it succeeded.
- Served the app with `python3 -m http.server` and visually verified the form populates by selecting `Qwen 3 235B` (Playwright screenshot captured successfully).
- No runtime errors observed during the manual/automated form-fill verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992545e04f483329faf8d01f43765fa)