### PR TITLE
Update param calculator Deepseek option values to deepseek-v3

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
         <select id="model-select">
           <option value="custom">Custom (enter your own values)</option>
           <option value="kimi">Kimi‑K2</option>
-          <option value="deepseek">Deepseek‑R1‑0528</option>
+          <option value="deepseek">Deepseek V3</option>
           <option value="qwen">Qwen3‑235B</option>
           <option value="gpt-oss-120b">gpt‑oss‑120b</option>
           <option value="glm-4.5-air">GLM-4.5-Air</option>

--- a/paramcalc.html
+++ b/paramcalc.html
@@ -23,8 +23,8 @@
           <select id="param-model-select">
             <option value="custom" selected>Custom (enter your own values)</option>
             <option value="kimi-k2">Kimi K2</option>
-            <option value="deepseek-r1-0528">DeepSeek R1 0528</option>
-            <option value="deepseek-r1-0528-mtp">DeepSeek R1 0528 MTP</option>
+            <option value="deepseek-v3">Deepseek V3</option>
+            <option value="deepseek-v3-mtp">Deepseek V3 MTP</option>
             <option value="glm-4.7">GLM 4.7</option>
             <option value="glm-5">GLM 5</option>
             <option value="qwen3-235b">Qwen 3 235B</option>

--- a/paramcalc.js
+++ b/paramcalc.js
@@ -611,7 +611,7 @@ function prefillParamModel(model) {
     // Update computed A and render
     updateComputedTotalLayers();
     calculateAndRender({ scroll: false });
-  } else if (model === 'deepseek-r1-0528') {
+  } else if (model === 'deepseek-v3') {
     // B, C
     setVal('dense_layers', '3'); // B
     setVal('moe_layers', '58'); // C
@@ -785,9 +785,9 @@ function prefillParamModel(model) {
     // Update computed A and render
     updateComputedTotalLayers();
     calculateAndRender({ scroll: false });
-  } else if (model === 'deepseek-r1-0528-mtp') {
-    // Start from base DeepSeek R1 0528, then override differences
-    prefillParamModel('deepseek-r1-0528');
+  } else if (model === 'deepseek-v3-mtp') {
+    // Start from base Deepseek V3, then override differences
+    prefillParamModel('deepseek-v3');
 
     const setVal = (id, v) => { const el = document.getElementById(id); if (el) el.value = v; };
 

--- a/script.js
+++ b/script.js
@@ -39,7 +39,7 @@ function prefillModel(model) {
     moeParamsEl.value = 14193524736;
     // Preserve KV cache value
   } else if (model === 'deepseek') {
-    // Deepseek‑R1‑0528 preset parameters
+    // Deepseek V3 preset parameters
     totalParamsEl.value = 671026419200;
     // Always‑active dense parameters per token
     denseParamsEl.value = 14563317248;


### PR DESCRIPTION
### Motivation
- Align the internal preset identifiers used by the parameter calculator with the renamed UI labels so the preset selection and prefill logic are consistent (`deepseek-v3` / `deepseek-v3-mtp`).
- Ensure the MTP preset continues to layer on the base Deepseek preset by delegating to the new base identifier without changing preset values or behavior.

### Description
- Changed the model option values in `paramcalc.html` from `deepseek-r1-0528`/`deepseek-r1-0528-mtp` to `deepseek-v3`/`deepseek-v3-mtp` while keeping visible labels as `Deepseek V3` and `Deepseek V3 MTP`.
- Updated the `prefillParamModel` branches in `paramcalc.js` to check for `deepseek-v3` and `deepseek-v3-mtp` and updated the MTP branch to call `prefillParamModel('deepseek-v3')` so it composes on the new identifier.

### Testing
- Ran `git diff --check` which completed successfully.
- Served the site with `python -m http.server 8000` and captured a screenshot of `paramcalc.html` using the Playwright helper which completed successfully.
- Verified repository status with `git status --short` and committed the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69940ed555d083329c9a81be849f352b)