### PR TITLE
Add Minimax M2.5 preset to param calculator

### DIFF
--- a/paramcalc.html
+++ b/paramcalc.html
@@ -27,6 +27,7 @@
             <option value="deepseek-r1-0528-mtp">DeepSeek R1 0528 MTP</option>
             <option value="glm-4.7">GLM 4.7</option>
             <option value="glm-5">GLM 5</option>
+            <option value="minimax-m2.5">Minimax M2.5</option>
             <option value="qwen3-235b">Qwen 3 235B</option>
           </select>
         </div>

--- a/paramcalc.js
+++ b/paramcalc.js
@@ -720,6 +720,72 @@ function prefillParamModel(model) {
     // Update computed A and render
     updateComputedTotalLayers();
     calculateAndRender({ scroll: false });
+  } else if (model === 'minimax-m2.5') {
+    // B, C
+    setVal('dense_layers', '0'); // B
+    setVal('moe_layers', '62'); // C
+
+    // D: Embedding/output matrices
+    setVal('embedding_shapes', [
+      '[200064, 3072]',
+      '[3072, 200064]'
+    ].join('\n'));
+
+    // E: Pre/post first/last norms (optional)
+    setVal('pre_first_norms', [
+      '[3072]'
+    ].join('\n'));
+
+    // F/G/H are blank for this model
+    setVal('dense_norms', '');
+    setVal('dense_attn', '');
+    setVal('dense_ffn', '');
+
+    // I, J
+    setVal('experts_per_layer', '256'); // I
+    setVal('active_experts', '8'); // J
+
+    // K, L, M: Shared expert disabled
+    setChecked('has_shared_expert', false);
+    updateSharedState();
+    setVal('shared_expert_scope', 'per_layer');
+    setVal('shared_expert_tensors', '');
+
+    // N: MoE attention tensors
+    setVal('moe_attn', [
+      '[3072, 6144]',
+      '[3072, 1024]',
+      '[3072, 1024]',
+      '[6144, 3072]'
+    ].join('\n'));
+
+    // O: MoE norms/transitional
+    setVal('moe_transitional', [
+      '[3072]',
+      '[3072]',
+      '[6144]',
+      '[1024]'
+    ].join('\n'));
+
+    // P: Shared FFN (always active)
+    setVal('moe_shared_ffn', [
+      '[3072, 256]',
+      '[256]'
+    ].join('\n'));
+
+    // Q: MoE experts tensors (includes expert dimension E)
+    setVal('moe_experts', [
+      '[256, 1536, 3072]',
+      '[256, 3072, 1536]',
+      '[256, 1536, 3072]'
+    ].join('\n'));
+
+    // Experts include E: checked
+    setChecked('experts_include_dim', true);
+
+    // Update computed A and render
+    updateComputedTotalLayers();
+    calculateAndRender({ scroll: false });
   } else if (model === 'qwen3-235b') {
     // B, C
     setVal('dense_layers', '0'); // B


### PR DESCRIPTION
### Motivation
- Provide a quick preset for the Minimax M2.5 model so users can populate the Param Calculator with the exact layer and tensor shapes requested.

### Description
- Added `Minimax M2.5` to the model dropdown in `paramcalc.html` so it can be selected from the UI.
- Implemented a new `minimax-m2.5` branch in `prefillParamModel` in `paramcalc.js` that sets `B=0`, `C=62`, `I=256`, `J=8`, leaves dense tensors `F/G/H` blank, disables the shared expert, and sets `experts_include_dim` to true.
- The preset fills tensors `D`, `E`, `N`, `O`, `P`, and `Q` per the provided shapes and then calls `updateComputedTotalLayers()` and `calculateAndRender()` to refresh the UI.

### Testing
- Ran `node --check paramcalc.js` to validate the script syntax and it completed successfully.
- Launched a local server with `python3 -m http.server 4173` and used an automated Playwright script to load `paramcalc.html`, select `minimax-m2.5`, and capture a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699410a2bfd88332942d7f7bd3e7b9a9)