### PR TITLE
Add GLM 4.7 Flash preset to paramcalc

### DIFF
--- a/paramcalc.html
+++ b/paramcalc.html
@@ -26,6 +26,7 @@
             <option value="deepseek-v3">Deepseek V3</option>
             <option value="deepseek-v3-mtp">Deepseek V3 MTP</option>
             <option value="glm-4.7">GLM 4.7</option>
+            <option value="glm-4.7-flash">GLM 4.7 Flash</option>
             <option value="glm-5">GLM 5</option>
             <option value="minimax-m2.5">Minimax M2.5</option>
             <option value="qwen3-235b">Qwen 3 235B</option>

--- a/paramcalc.js
+++ b/paramcalc.js
@@ -510,6 +510,100 @@ function prefillParamModel(model) {
     // Update computed A and render
     updateComputedTotalLayers();
     calculateAndRender({ scroll: false });
+  } else if (model === 'glm-4.7-flash') {
+    // B, C
+    setVal('dense_layers', '1'); // B
+    setVal('moe_layers', '47'); // C
+
+    // D: Embedding/output matrices
+    setVal('embedding_shapes', [
+      '[154880, 2048]',
+      '[154880, 2048]'
+    ].join('\n'));
+
+    // E: Pre/post first/last norms (optional)
+    setVal('pre_first_norms', [
+      '[2048]',
+      '[2048]',
+      '[2048]',
+      '[2048]',
+      '[2048, 4096]'
+    ].join('\n'));
+
+    // F: Dense layer norms
+    setVal('dense_norms', [
+      '[2048]',
+      '[2048]',
+      '[768]',
+      '[512]'
+    ].join('\n'));
+
+    // G: Dense attention tensors
+    setVal('dense_attn', [
+      '[768, 2048]',
+      '[5120, 768]',
+      '[576, 2048]',
+      '[8960, 512]',
+      '[2048, 5120]'
+    ].join('\n'));
+
+    // H: Dense FFN tensors
+    setVal('dense_ffn', [
+      '[10240, 2048]',
+      '[10240, 2048]',
+      '[2048, 10240]'
+    ].join('\n'));
+
+    // I, J
+    setVal('experts_per_layer', '64'); // I
+    setVal('active_experts', '4'); // J
+
+    // K, L, M: Shared expert
+    setChecked('has_shared_expert', true);
+    updateSharedState();
+    setVal('shared_expert_scope', 'per_layer');
+    setVal('shared_expert_tensors', [
+      '[1536, 2048]',
+      '[1536, 2048]',
+      '[2048, 1536]'
+    ].join('\n'));
+
+    // N: MoE attention tensors
+    setVal('moe_attn', [
+      '[768, 2048]',
+      '[5120, 768]',
+      '[576, 2048]',
+      '[8960, 512]',
+      '[2048, 5120]'
+    ].join('\n'));
+
+    // O: MoE norms/transitional
+    setVal('moe_transitional', [
+      '[2048]',
+      '[2048]',
+      '[768]',
+      '[512]'
+    ].join('\n'));
+
+    // P: Gate input, biases, other FFN (always active)
+    setVal('moe_shared_ffn', [
+      '[64, 2048]',
+      '[64]'
+    ].join('\n'));
+
+    // Q: MoE experts tensors (includes expert dimension E)
+    setVal('moe_experts', [
+      '[64, 1536, 2048]',
+      '[64, 1536, 2048]',
+      '[64, 2048, 1536]'
+    ].join('\n'));
+
+    // Experts include E: checked
+    setChecked('experts_include_dim', true);
+
+    // Update computed A and render
+    updateComputedTotalLayers();
+    calculateAndRender({ scroll: false });
   } else if (model === 'glm-5') {
     // B, C
     setVal('dense_layers', '3'); // B


### PR DESCRIPTION
### Motivation
- Provide a built-in preset for the GLM 4.7 Flash model so users can load the provided A→Q shapes and options into the parameter calculator quickly.
- Ensure the preset mirrors the intended configuration: MoE layers, expert shapes, shared expert enabled, and expert-dimension-included semantics.

### Description
- Add a new dropdown option `GLM 4.7 Flash` in `paramcalc.html` wired to the preset value `glm-4.7-flash`.
- Implement a `glm-4.7-flash` branch in `prefillParamModel` inside `paramcalc.js` that sets `B=1`, `C=47` and fills fields `D`–`Q` with the supplied HF-style tensor shapes.
- Configure the preset to enable `Include shared expert`, set `Shared expert scope` to `per_layer`, and check `Tensors include expert dimension (E)`.
- Ensure the preset triggers `updateComputedTotalLayers()` and `calculateAndRender()` after populating the fields.

### Testing
- Ran `rg -n "glm-4.7-flash|GLM 4.7 Flash" paramcalc.html paramcalc.js` to confirm the new option and preset branch are present, which succeeded.
- Attempted an automated browser check by starting `python3 -m http.server 4173` and running a Playwright script to select the preset and capture a screenshot, but Playwright returned `ERR_EMPTY_RESPONSE` when loading the local page in this environment (server process started).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699418ed61ac8332b8e05ef6978329b8)