### PR TITLE
Add Qwen 3 30B preset to ParamCalc

### DIFF
--- a/paramcalc.html
+++ b/paramcalc.html
@@ -29,6 +29,7 @@
             <option value="glm-4.7-flash">GLM 4.7 Flash</option>
             <option value="glm-5">GLM 5</option>
             <option value="minimax-m2.5">Minimax M2.5</option>
+            <option value="qwen3-30b">Qwen 3 30B</option>
             <option value="qwen3-235b">Qwen 3 235B</option>
           </select>
         </div>

--- a/paramcalc.js
+++ b/paramcalc.js
@@ -876,6 +876,71 @@ function prefillParamModel(model) {
     // Update computed A and render
     updateComputedTotalLayers();
     calculateAndRender({ scroll: false });
+  } else if (model === 'qwen3-30b') {
+    // B, C
+    setVal('dense_layers', '0'); // B
+    setVal('moe_layers', '48'); // C
+
+    // D: Embedding/output matrices
+    setVal('embedding_shapes', [
+      '[151936, 2048]',
+      '[151936, 2048]'
+    ].join('\n'));
+
+    // E: Pre/post first/last norms (optional)
+    setVal('pre_first_norms', [
+      '[2048]'
+    ].join('\n'));
+
+    // F/G/H: Dense layers are unused for this model
+    setVal('dense_norms', '');
+    setVal('dense_attn', '');
+    setVal('dense_ffn', '');
+
+    // I, J
+    setVal('experts_per_layer', '128'); // I
+    setVal('active_experts', '8'); // J
+
+    // K, L, M: Shared expert disabled
+    setChecked('has_shared_expert', false);
+    updateSharedState();
+    setVal('shared_expert_scope', 'per_layer');
+    setVal('shared_expert_tensors', '');
+
+    // N: MoE attention tensors
+    setVal('moe_attn', [
+      '[4096, 2048]',
+      '[512, 2048]',
+      '[512, 2048]',
+      '[2048, 4096]',
+      '[128]',
+      '[128]'
+    ].join('\n'));
+
+    // O: MoE norms/transitional
+    setVal('moe_transitional', [
+      '[2048]',
+      '[2048]'
+    ].join('\n'));
+
+    // P: Gate input, biases, other FFN (always active)
+    setVal('moe_shared_ffn', [
+      '[128, 2048]'
+    ].join('\n'));
+
+    // Q: MoE experts tensors (includes expert dimension E)
+    setVal('moe_experts', [
+      '[128, 768, 2048]',
+      '[128, 768, 2048]',
+      '[128, 2048, 768]'
+    ].join('\n'));
+
+    // Experts include E: checked
+    setChecked('experts_include_dim', true);
+
+    // Update computed A and render
+    updateComputedTotalLayers();
+    calculateAndRender({ scroll: false });
   } else if (model === 'qwen3-235b') {
     // B, C
     setVal('dense_layers', '0'); // B


### PR DESCRIPTION
### Motivation
- Provide a ready-to-use ParamCalc preset for the Qwen 3 30B MoE model so users can quickly load the correct A→Q parameter configuration. 

### Description
- Add a `Qwen 3 30B` option to the model preset dropdown in `paramcalc.html`.  
- Implement a `qwen3-30b` branch in `prefillParamModel` inside `paramcalc.js` that sets the requested A→Q values, disables dense-layer tensors, and marks experts as including the expert dimension (`experts_include_dim = true`).  
- Update computed total-layers rendering by calling `updateComputedTotalLayers()` and `calculateAndRender({ scroll: false })` after the preset is applied. 

### Testing
- Ran `node --check paramcalc.js` which completed without errors.  
- Ran `git diff --check` which reported no whitespace or diff-check issues.  
- Attempted an automated browser snapshot via Playwright to visually validate the UI preset selection but the navigation timed out in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69941c577314833282f38cd72c0306e5)