### PR TITLE
Add GPT-OSS 120B preset to param calculator

### DIFF
--- a/paramcalc.html
+++ b/paramcalc.html
@@ -29,6 +29,7 @@
             <option value="glm-4.7-flash">GLM 4.7 Flash</option>
             <option value="glm-5">GLM 5</option>
             <option value="minimax-m2.5">Minimax M2.5</option>
+            <option value="gpt-oss-120b">GPT-OSS 120B</option>
             <option value="qwen3-30b">Qwen 3 30B</option>
             <option value="qwen3-235b">Qwen 3 235B</option>
           </select>

--- a/paramcalc.js
+++ b/paramcalc.js
@@ -876,6 +876,78 @@ function prefillParamModel(model) {
     // Update computed A and render
     updateComputedTotalLayers();
     calculateAndRender({ scroll: false });
+  } else if (model === 'gpt-oss-120b') {
+    // B, C
+    setVal('dense_layers', '0'); // B
+    setVal('moe_layers', '36'); // C
+
+    // D: Embedding/output matrices
+    setVal('embedding_shapes', [
+      '[201088, 2880]',
+      '[201088, 2880]'
+    ].join('\n'));
+
+    // E: Pre/post first/last norms (optional)
+    setVal('pre_first_norms', [
+      '[2880]'
+    ].join('\n'));
+
+    // F/G/H: Dense layers are unused for this model
+    setVal('dense_norms', '');
+    setVal('dense_attn', '');
+    setVal('dense_ffn', '');
+
+    // I, J
+    setVal('experts_per_layer', '128'); // I
+    setVal('active_experts', '4'); // J
+
+    // K, L, M: Shared expert disabled
+    setChecked('has_shared_expert', false);
+    updateSharedState();
+    setVal('shared_expert_scope', 'per_layer');
+    setVal('shared_expert_tensors', '');
+
+    // N: MoE attention tensors
+    setVal('moe_attn', [
+      '[4096, 2880]',
+      '[4096]',
+      '[512, 2880]',
+      '[512]',
+      '[512, 2880]',
+      '[512]',
+      '[2880, 4096]',
+      '[2880]',
+      '[64]'
+    ].join('\n'));
+
+    // O: MoE norms/transitional
+    setVal('moe_transitional', [
+      '[2880]',
+      '[2880]'
+    ].join('\n'));
+
+    // P: Gate input, biases, other FFN (always active)
+    setVal('moe_shared_ffn', [
+      '[128, 2880]',
+      '[128]'
+    ].join('\n'));
+
+    // Q: MoE experts tensors (includes expert dimension E)
+    setVal('moe_experts', [
+      '[128, 5760, 90, 16]',
+      '[128, 5760, 90]',
+      '[128, 5760]',
+      '[128, 2880, 90, 16]',
+      '[128, 2880, 90]',
+      '[128, 2880]'
+    ].join('\n'));
+
+    // Experts include E: checked
+    setChecked('experts_include_dim', true);
+
+    // Update computed A and render
+    updateComputedTotalLayers();
+    calculateAndRender({ scroll: false });
   } else if (model === 'qwen3-30b') {
     // B, C
     setVal('dense_layers', '0'); // B


### PR DESCRIPTION
### Motivation
- Provide a ready-to-use preset for the GPT-OSS 120B Mixture-of-Experts model so users can populate the Param Calculator with the exact A→Q inputs for quick estimates.

### Description
- Added a new `GPT-OSS 120B` option to the model dropdown in `paramcalc.html` so the preset is selectable.
- Implemented a `gpt-oss-120b` branch in `prefillParamModel(...)` inside `paramcalc.js` that sets the exact inputs provided: `B=0`, `C=36`, `D`, `E`, `N`, `O`, `P`, and `Q` tensors (as listed), `F/G/H` left empty, `I=128`, `J=4`, shared expert disabled, and `experts_include_dim` checked.
- Ensured the preset calls `updateComputedTotalLayers()` and `calculateAndRender()` after setting values to refresh computed totals and results.

### Testing
- Ran `node --check paramcalc.js` to verify the modified script has no syntax errors; the check succeeded.
- Attempted a headless browser validation (served via `python3 -m http.server 8000` and a Playwright script) to select the new preset and capture a screenshot, but the Playwright run timed out in this environment and did not produce a screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69941e545b248332aa08fe43aaccf517)