### PR TITLE
Add GPT-OSS 20B preset to param calculator

### DIFF
--- a/paramcalc.html
+++ b/paramcalc.html
@@ -29,6 +29,7 @@
             <option value="glm-4.7-flash">GLM 4.7 Flash</option>
             <option value="glm-5">GLM 5</option>
             <option value="minimax-m2.5">Minimax M2.5</option>
+            <option value="gpt-oss-20b">GPT-OSS 20B</option>
             <option value="gpt-oss-120b">GPT-OSS 120B</option>
             <option value="qwen3-30b">Qwen 3 30B</option>
             <option value="qwen3-235b">Qwen 3 235B</option>

--- a/paramcalc.js
+++ b/paramcalc.js
@@ -876,6 +876,78 @@ function prefillParamModel(model) {
     // Update computed A and render
     updateComputedTotalLayers();
     calculateAndRender({ scroll: false });
+  } else if (model === 'gpt-oss-20b') {
+    // B, C
+    setVal('dense_layers', '0'); // B
+    setVal('moe_layers', '24'); // C
+
+    // D: Embedding/output matrices
+    setVal('embedding_shapes', [
+      '[201088, 2880]',
+      '[201088, 2880]'
+    ].join('\n'));
+
+    // E: Pre/post first/last norms (optional)
+    setVal('pre_first_norms', [
+      '[2880]'
+    ].join('\n'));
+
+    // F/G/H: Dense layers are unused for this model
+    setVal('dense_norms', '');
+    setVal('dense_attn', '');
+    setVal('dense_ffn', '');
+
+    // I, J
+    setVal('experts_per_layer', '32'); // I
+    setVal('active_experts', '4'); // J
+
+    // K, L, M: Shared expert disabled
+    setChecked('has_shared_expert', false);
+    updateSharedState();
+    setVal('shared_expert_scope', 'per_layer');
+    setVal('shared_expert_tensors', '');
+
+    // N: MoE attention tensors
+    setVal('moe_attn', [
+      '[4096, 2880]',
+      '[4096]',
+      '[512, 2880]',
+      '[512]',
+      '[512, 2880]',
+      '[512]',
+      '[2880, 4096]',
+      '[2880]',
+      '[64]'
+    ].join('\n'));
+
+    // O: MoE norms/transitional
+    setVal('moe_transitional', [
+      '[2880]',
+      '[2880]'
+    ].join('\n'));
+
+    // P: Gate input, biases, other FFN (always active)
+    setVal('moe_shared_ffn', [
+      '[32, 2880]',
+      '[32]'
+    ].join('\n'));
+
+    // Q: MoE experts tensors (includes expert dimension E)
+    setVal('moe_experts', [
+      '[32, 5760, 90, 16]',
+      '[32, 5760, 90]',
+      '[32, 5760]',
+      '[32, 2880, 90, 16]',
+      '[32, 2880, 90]',
+      '[32, 2880]'
+    ].join('\n'));
+
+    // Experts include E: checked
+    setChecked('experts_include_dim', true);
+
+    // Update computed A and render
+    updateComputedTotalLayers();
+    calculateAndRender({ scroll: false });
   } else if (model === 'gpt-oss-120b') {
     // B, C
     setVal('dense_layers', '0'); // B


### PR DESCRIPTION
### Motivation

- Provide a ready-to-use preset for the GPT-OSS 20B model so users can populate the Param Calculator with the exact A→Q tensors without manual entry.

### Description

- Add `GPT-OSS 20B` to the model dropdown in `paramcalc.html` so it can be selected from the UI.
- Implement a `gpt-oss-20b` branch in `prefillParamModel` inside `paramcalc.js` that sets the requested A→Q values (B=0, C=24; D and E as provided; F/G/H empty; I=32, J=4; shared expert unchecked; N/O/P/Q tensors as provided; `experts_include_dim` checked) and triggers `updateComputedTotalLayers()` and `calculateAndRender()`.
- Keep existing presets and rendering behavior unchanged.

### Testing

- Ran `node --check paramcalc.js` which completed successfully.
- Launched a static server with `python3 -m http.server` to serve the UI successfully, then attempted an automated browser screenshot with Playwright; the Chromium process crashed with a SIGSEGV in this environment so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69941f3ba2808332a3e764c92e12de05)