### PR TITLE
Fix GPT-OSS paramcalc presets to count logical MoE parameters

### DIFF
--- a/paramcalc.js
+++ b/paramcalc.js
@@ -934,11 +934,9 @@ function prefillParamModel(model) {
 
     // Q: MoE experts tensors (includes expert dimension E)
     setVal('moe_experts', [
-      '[32, 5760, 90, 16]',
-      '[32, 5760, 90]',
+      '[32, 5760, 2880]',
+      '[32, 2880, 5760]',
       '[32, 5760]',
-      '[32, 2880, 90, 16]',
-      '[32, 2880, 90]',
       '[32, 2880]'
     ].join('\n'));
 
@@ -1006,11 +1004,9 @@ function prefillParamModel(model) {
 
     // Q: MoE experts tensors (includes expert dimension E)
     setVal('moe_experts', [
-      '[128, 5760, 90, 16]',
-      '[128, 5760, 90]',
+      '[128, 5760, 2880]',
+      '[128, 2880, 5760]',
       '[128, 5760]',
-      '[128, 2880, 90, 16]',
-      '[128, 2880, 90]',
       '[128, 2880]'
     ].join('\n'));
 


### PR DESCRIPTION
### Motivation
- GPT-OSS 20B and 120B presets were undercounting total parameters because they used quantized checkpoint storage layouts (packing dimensions like `...,90,16` and `...,90`) as if they were logical weight tensors. 
- For parameter counting we must use dense-equivalent expert matrix shapes so the reported model scale reflects actual logical parameters. 
- Keep existing handling of expert dimension (`experts_include_dim`) and bias entries intact while correcting the shapes used for math.

### Description
- Updated `paramcalc.js` to replace the `moe_experts` preset block for `gpt-oss-20b` with logical expert weight shapes `['[32, 5760, 2880]', '[32, 2880, 5760]', '[32, 5760]', '[32, 2880]']` instead of quantization-packed storage shapes. 
- Updated `paramcalc.js` to replace the `moe_experts` preset block for `gpt-oss-120b` with logical expert weight shapes `['[128, 5760, 2880]', '[128, 2880, 5760]', '[128, 5760]', '[128, 2880]']` instead of quantization-packed storage shapes. 
- No changes to expert counting flags or other model presets were made; only the expert tensor shape lines were replaced.

### Testing
- Ran `node --check paramcalc.js` to validate the JavaScript syntax and it completed successfully. 
- Verified the updated `moe_experts` lines are present in `paramcalc.js` via a diff inspection and the file passes syntax check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699425e5ec308332b1512cdc573159b5)