### PR TITLE
Fix GPT‑OSS MoE expert parameter shapes in presets

### DIFF
--- a/paramcalc.js
+++ b/paramcalc.js
@@ -934,11 +934,9 @@ function prefillParamModel(model) {
 
     // Q: MoE experts tensors (includes expert dimension E)
     setVal('moe_experts', [
-      '[32, 5760, 90, 16]',
-      '[32, 5760, 90]',
+      '[32, 5760, 2880]',
+      '[32, 2880, 5760]',
       '[32, 5760]',
-      '[32, 2880, 90, 16]',
-      '[32, 2880, 90]',
       '[32, 2880]'
     ].join('\n'));
 
@@ -1006,11 +1004,9 @@ function prefillParamModel(model) {
 
     // Q: MoE experts tensors (includes expert dimension E)
     setVal('moe_experts', [
-      '[128, 5760, 90, 16]',
-      '[128, 5760, 90]',
+      '[128, 5760, 2880]',
+      '[128, 2880, 5760]',
       '[128, 5760]',
-      '[128, 2880, 90, 16]',
-      '[128, 2880, 90]',
       '[128, 2880]'
     ].join('\n'));
 


### PR DESCRIPTION
### Motivation
- The GPT‑OSS presets used quantized checkpoint storage layouts (packed dims like `90,16` and `90`) as if they were logical model-weight tensors, which undercounts total parameters.
- For correct parameter counts the logical dense-equivalent expert weight shapes must be used (per‑expert gate_up/down matrices and biases) instead of packed quantization storage shapes.
- This change aims to fix reported undercounting for `gpt-oss-20b` and `gpt-oss-120b` so the calculator reports model-scale‑consistent totals.

### Description
- Replaced the `moe_experts` preset entries for `gpt-oss-20b` in `paramcalc.js` to use logical shapes `['[32, 5760, 2880]', '[32, 2880, 5760]', '[32, 5760]', '[32, 2880]']` in place of the packed quantization shapes.
- Replaced the `moe_experts` preset entries for `gpt-oss-120b` in `paramcalc.js` to use logical shapes `['[128, 5760, 2880]', '[128, 2880, 5760]', '[128, 5760]', '[128, 2880]']` in place of the packed quantization shapes.
- Left `experts_include_dim` set to `true` and retained per‑expert bias entries so logical parameter math includes biases.

### Testing
- Ran `node --check paramcalc.js` to validate the JavaScript syntax, and it completed successfully.
- Ran `rg -n "gpt-oss-20b|gpt-oss-120b|\[32, 5760, 2880\]|\[128, 5760, 2880\]|90, 16|90\]" paramcalc.js` to verify the new logical shapes are present and quantization storage patterns were removed, and the search returned the expected updated lines.
- Performed `git status --short` and committed the change with message `Fix GPT-OSS MoE expert param shapes in presets` to record the update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699425e5ec308332b1512cdc573159b5)