### PR TITLE
Fix incorrect GPT-OSS MoE down projection tensor dimensions in paramcalc preset

### DIFF
--- a/paramcalc.js
+++ b/paramcalc.js
@@ -957,7 +957,7 @@ function prefillParamModel(model) {
     // Q: MoE experts tensors (includes expert dimension E)
     setVal('moe_experts', [
       '[32, 5760, 2880]',
-      '[32, 2880, 5760]',
+      '[32, 2880, 2880]',
       '[32, 5760]',
       '[32, 2880]'
     ].join('\n'));
@@ -1027,7 +1027,7 @@ function prefillParamModel(model) {
     // Q: MoE experts tensors (includes expert dimension E)
     setVal('moe_experts', [
       '[128, 5760, 2880]',
-      '[128, 2880, 5760]',
+      '[128, 2880, 2880]',
       '[128, 5760]',
       '[128, 2880]'
     ].join('\n'));


### PR DESCRIPTION
### Motivation
- Correct the GPT-OSS presets so the MoE expert down-projection uses the correct `intermediate_size × hidden_size` shape, since both are `2880` for these models and the previous shape `[E, 2880, 5760]` was incorrect.
- Align the preset parameter counts with HF’s reported totals for GPT-OSS models after fixing the expert tensor shape.

### Description
- Updated `paramcalc.js` presets for `gpt-oss-20b` and `gpt-oss-120b` in the `moe_experts` list to change the down-projection tensor from `[32, 2880, 5760]`/`[128, 2880, 5760]` to `[32, 2880, 2880]`/`[128, 2880, 2880]` respectively.
- The change is localized to the `prefillParamModel` logic that seeds the `Q` (MoE experts tensors) preset for those models.

### Testing
- Ran an automated arithmetic verification script that recomputed totals for the corrected presets and produced `20,914,757,184` for GPT-OSS 20B and `116,829,156,672` for GPT-OSS 120B, matching the expected values. (Succeeded.)
- Attempted an automated browser-based render check using `playwright`, but the environment lacked the `playwright` module so that test failed; the arithmetic verification confirms the numeric fix. (Failed due to missing dependency.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994297cda8883328f450f0010344124)